### PR TITLE
Album preview rating

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.5",
         "@tailwindcss/forms": "^0.5.3",
+        "@tailwindcss/line-clamp": "^0.4.2",
         "@tanstack/react-query": "^4.24.4",
         "axios": "^1.3.0",
         "daisyui": "^2.47.0",
@@ -1335,6 +1336,14 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
+      "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.5",
     "@tailwindcss/forms": "^0.5.3",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "@tanstack/react-query": "^4.24.4",
     "axios": "^1.3.0",
     "daisyui": "^2.47.0",

--- a/web/src/components/Album.jsx
+++ b/web/src/components/Album.jsx
@@ -4,7 +4,7 @@ function Album(props) {
     const { img, size, name } = props.album;
     
     return (
-        <div className="relative transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-110">
+        <div className="relative transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-105">
             <Link to="/User/AlbumDetails">
 
                 {/* Album Art */}

--- a/web/src/components/Album.jsx
+++ b/web/src/components/Album.jsx
@@ -8,10 +8,10 @@ function Album(props) {
             <Link to="/User/AlbumDetails">
 
                 {/* Album Art */}
-                <img className="ring-2 ring-gray-500" src = { img } width = { size } height = { size }/>
+                <img className="ring-2 ring-gray-500" src={img} width={size} height={size}/>
 
                 {/* Overlay mask with album name */}
-                <div className="absolute inset-0 flex items-center justify-center text-white bg-black bg-opacity-50 opacity-0 hover:opacity-100 transition-opacity">
+                <div className={`max-w-[${size}px] max-h-[${size}px] absolute inset-0 flex items-center justify-center text-white bg-black bg-opacity-50 opacity-0 hover:opacity-100 transition-opacity`}>
                     <p className="text-xs text-center max-w-full line-clamp-2">{ name || "Click for album details" }</p>
                 </div>
 

--- a/web/src/components/Album.jsx
+++ b/web/src/components/Album.jsx
@@ -1,12 +1,23 @@
-function Album(props) {
-    // TO DO: Eventually send a list of albums
-    const { img, size } = props.album;
+import { Link } from "react-router-dom"
 
+function Album(props) {
+    const { img, size, name } = props.album;
+    
     return (
-        <div className="transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-110">
-            <img className="ring-2 ring-gray-500" src={img} width={size} height={size}/>
+        <div className="relative transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-110">
+            <Link to="/User/AlbumDetails">
+
+                {/* Album Art */}
+                <img className="ring-2 ring-gray-500" src = { img } width = { size } height = { size }/>
+
+                {/* Overlay mask with album name */}
+                <div className="absolute inset-0 flex items-center justify-center text-white bg-black bg-opacity-50 opacity-0 hover:opacity-100 transition-opacity">
+                    <p className="text-xs text-center max-w-full line-clamp-2">{ name || "Click for album details" }</p>
+                </div>
+
+            </Link>
         </div>
-    );
+      );
 }
 
 export default Album

--- a/web/src/components/AlbumReview.jsx
+++ b/web/src/components/AlbumReview.jsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router-dom"
+
+// Components
+import Avatar from "./Avatar"
+import Stars from "./Stars"
+
+function AlbumReview(props) {
+    const { img, size, user, albumName, rating} = props.album;
+
+    return (
+        <div className="relative transition ease-in-out delay-150 hover:-translate-y-1 hover:scale-105 max-w-[100px]">
+
+            <Link to="/User/AlbumDetails">
+                <div className="ring-2 ring-gray-500 inline-block">
+                    {/* Album Art */}
+                    <img src={img} width={size} height={size}/>
+
+                    {/* Overlay mask with album name */}
+                    <div className={`max-w-[100px] max-h-[100px] absolute inset-0 flex items-center justify-center text-white bg-black bg-opacity-50 opacity-0 hover:opacity-100 transition-opacity`}>
+                        <p className="text-xs text-center line-clamp-2">{ albumName || "Click for album details" }</p>
+                    </div>
+
+                    <div className="bg-gray-700 px-2 py-2">
+                        <p className="text-xs text-left flex flex-row">
+                            <Avatar user={{ profilePic: null, firstName: user, size: "4" }} />
+                            <p className="text-md pl-2 font-bold">{user}</p>
+                        </p>
+                    </div>
+                </div>
+                
+                <div className="flex flex-row justify-between text-xs pt-1 text-gray-400">
+                    <Stars rating={rating} />
+                    <p>Feb 18</p>
+                </div>
+            </Link>
+        </div>
+      );
+}
+
+export default AlbumReview

--- a/web/src/components/Avatar.jsx
+++ b/web/src/components/Avatar.jsx
@@ -7,7 +7,7 @@ function Avatar(props) {
                 { profilePic ? 
                     <img src={ profilePic } />
                     :
-                    <span className="text-md text-white">
+                    <span className="text-md text-white uppercase">
                         { firstName ? firstName[0]: "" }
                     </span> 
                 }     

--- a/web/src/components/Review.jsx
+++ b/web/src/components/Review.jsx
@@ -16,7 +16,7 @@ function Review(props) {
 
                 {/* Album Art */}
                 <div className="p-3 m-2">
-                    <Album album = {{ img : albumImg, size : "100" }} />
+                    <Album album = {{ img : albumImg, size : "100", name : albumName }} />
                 </div>
 
                 <div className="flex flex-col p-3 gap-4 w-4/5">

--- a/web/src/components/Review.jsx
+++ b/web/src/components/Review.jsx
@@ -56,13 +56,13 @@ function Review(props) {
 
                         <div
                         onClick={handleLikeClick}
-                        className="flex gap-1 items-center transition duration-300 ease-in-out hover:text-gray-400 cursor-pointer"
+                        className="flex gap-1 items-center transition duration-300 ease-in-out hover:text-gray-400 cursor-pointer font-bold"
                         >
-                            <p className={`${isLiked ? 'text-red-500' : 'text-gray-500'} heart-icon`}>
+                            <p className={`${isLiked ? 'text-red-500' : 'text-gray-500'}`}>
                                 ❤︎
                             </p>
 
-                            <p className={`${isLiked ? 'font-bold text-gray-300' : ''}`}>
+                            <p className={`${isLiked ? 'text-gray-300' : ''}`}>
                                 {isLiked ? 'Liked' : 'Like review'}
                             </p>
                         </div>

--- a/web/src/components/Review.jsx
+++ b/web/src/components/Review.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 // Components
 import Album from "../components/Album"
 import Avatar from "../components/Avatar"
@@ -8,6 +10,13 @@ import Heart from '/heart.svg';
 
 function Review(props) {
     const { user, profilePic, rating, review, albumImg, albumName, albumYear, artist} = props.review;
+
+    const [isLiked, setIsLiked] = useState(false);
+
+    const handleLikeClick = () => {
+        setIsLiked(!isLiked);
+    }
+    
 
     return (
         <div className="max-w-6xl mx-auto">
@@ -43,19 +52,26 @@ function Review(props) {
 
                     {/* Review */}
                     <p className="text-md">{review}</p>
+                      <div className="flex flex-row gap-2 text-gray-500 text-sm">
 
-                    <div className="flex flex-row gap-2 text-gray-500 text-sm">
-                        <img src={Heart} width="15" alt="Heart" />
-                        <p>Like review</p>
+                        <div
+                        onClick={handleLikeClick}
+                        className="flex gap-1 items-center transition duration-300 ease-in-out hover:text-gray-400 cursor-pointer"
+                        >
+                            <p className={`${isLiked ? 'text-red-500' : 'text-gray-500'} heart-icon`}>
+                                ❤︎
+                            </p>
+
+                            <p className={`${isLiked ? 'font-bold text-gray-300' : ''}`}>
+                                {isLiked ? 'Liked' : 'Like review'}
+                            </p>
+                        </div>
+
                         <p>2000 likes</p>
                     </div>
                     
                 </div>
             </div>
-
-            {/* Border Line */}
-            {/* <div className="border-t border-gray-600 max-w-6xl mx-auto" /> */}
-
         </div>
     );
 }

--- a/web/src/components/Stars.jsx
+++ b/web/src/components/Stars.jsx
@@ -1,25 +1,25 @@
 function starSwtich(star) {
     switch (star) {
         case 1:
-            return <div className="text-trillBlue text-md">½</div>;
+            return <div className="text-trillBlue text-md font-bold">½</div>;
         case 2:
-            return <div className="text-trillBlue text-md">★</div>;
+            return <div className="text-trillBlue text-md font-bold">★</div>;
         case 3:
-            return <div className="text-trillBlue text-md">★½</div>;
+            return <div className="text-trillBlue text-md font-bold">★½</div>;
         case 4:
-            return <div className="text-trillBlue text-md">★★</div>;
+            return <div className="text-trillBlue text-md font-bold">★★</div>;
         case 5:
-            return <div className="text-trillBlue text-md">★★½</div>;
+            return <div className="text-trillBlue text-md font-bold">★★½</div>;
         case 6:
-            return <div className="text-trillBlue text-md">★★★</div>;
+            return <div className="text-trillBlue text-md font-bold">★★★</div>;
         case 7:
-            return <div className="text-trillBlue text-md">★★★½</div>;
+            return <div className="text-trillBlue text-md font-bold">★★★½</div>;
         case 8:
-            return <div className="text-trillBlue text-md">★★★★</div>;
+            return <div className="text-trillBlue text-md font-bold">★★★★</div>;
         case 9:
-            return <div className="text-trillBlue text-md">★★★★½</div>;
+            return <div className="text-trillBlue text-md font-bold">★★★★½</div>;
         case 10:
-            return <div className="text-trillBlue text-md">★★★★★</div>;
+            return <div className="text-trillBlue text-md font-bold">★★★★★</div>;
     }
 }
 

--- a/web/src/components/Titles.jsx
+++ b/web/src/components/Titles.jsx
@@ -7,7 +7,7 @@ function Titles(props) {
             <div className="flex max-w-6xl mx-auto justify-between text-gray-400 pr-1 pl-1">
                 {props.title}
 
-                {props.title === "News" ? "" : 
+                {props.title === "Recent News" ? "" : 
                     <Link to="/User/More">
                         More <ArrowRightIcon />
                     </Link> 

--- a/web/src/pages/Discover.jsx
+++ b/web/src/pages/Discover.jsx
@@ -8,6 +8,7 @@ import NewsCard from "../components/NewsCard";
 import Album from "../components/Album";
 import Review from "../components/Review";
 import Loading from "../components/Loading";
+import AlbumReview from "../components/AlbumReview"
 
 const newsInfo = {
     title: "The 200 Greatest Singers of All Time", 
@@ -64,66 +65,71 @@ function Discover() {
             </section>
             
             {/* Album Discovery */}
-            <section> 
+            <section className="pt-14"> 
                 <Titles title="Popular Albums This Week - Globally"/>
-                    <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto pb-5">
-                        <Album album = {{ img: "https://is2-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/1200x1200bf-60.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/627c1023d3c744a67a846260/1:1/w_600/Kendrick-Lamar-Mr-Morale-And-The-Big-Steppers.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/60f6cf8ec64eabe66d59ccf1/1:1/w_600/Coldplay.jpeg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/51kK5l3-WTL._UXNaN_FMjpg_QL85_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/a/ad/Beyonc%C3%A9_-_Renaissance.png/220px-Beyonc%C3%A9_-_Renaissance.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100"}} />
-                    </div>
+                <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
+                    <Album album = {{ img: "https://is2-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/1200x1200bf-60.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100"}} />
+                    <Album album = {{ img: "https://media.pitchfork.com/photos/627c1023d3c744a67a846260/1:1/w_600/Kendrick-Lamar-Mr-Morale-And-The-Big-Steppers.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://media.pitchfork.com/photos/60f6cf8ec64eabe66d59ccf1/1:1/w_600/Coldplay.jpeg", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100"}} />
+                    <Album album = {{ img: "https://m.media-amazon.com/images/I/51kK5l3-WTL._UXNaN_FMjpg_QL85_.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/a/ad/Beyonc%C3%A9_-_Renaissance.png/220px-Beyonc%C3%A9_-_Renaissance.png", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100"}} />
+                </div>
+            </section>
 
+            <section className="pt-14"> 
                 <Titles title="Popular Reviews This Week - Globally"/>
-                    <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto pb-5">
-                        <Album album = {{ img: "https://is2-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/1200x1200bf-60.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/627c1023d3c744a67a846260/1:1/w_600/Kendrick-Lamar-Mr-Morale-And-The-Big-Steppers.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/60f6cf8ec64eabe66d59ccf1/1:1/w_600/Coldplay.jpeg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/51kK5l3-WTL._UXNaN_FMjpg_QL85_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/a/ad/Beyonc%C3%A9_-_Renaissance.png/220px-Beyonc%C3%A9_-_Renaissance.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100"}} />
-                    </div>
+                <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
+                    <AlbumReview album={{ img: "https://m.media-amazon.com/images/I/51kK5l3-WTL._UXNaN_FMjpg_QL85_.jpg", size: "100", user: "dmflo", rating: 2}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100", user: "avwede", rating: 5}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "csmi", rating: 10}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100", user: "avwede", rating: 1}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "chian", rating: 9}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100", user: "avwede", rating: 2}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "prathik",rating: 10}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "chris", rating: 5}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100", user: "avwede", rating: 10}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100", user: "john", rating: 8}} />
+                </div>
+            </section>
 
+            <section className="pt-14"> 
                 <Titles title="New From Friends"/>
-                    <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto pb-5">
-                        <Album album = {{ img: "https://is2-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/1200x1200bf-60.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/627c1023d3c744a67a846260/1:1/w_600/Kendrick-Lamar-Mr-Morale-And-The-Big-Steppers.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/60f6cf8ec64eabe66d59ccf1/1:1/w_600/Coldplay.jpeg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/51kK5l3-WTL._UXNaN_FMjpg_QL85_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/a/ad/Beyonc%C3%A9_-_Renaissance.png/220px-Beyonc%C3%A9_-_Renaissance.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100"}} />
-                    </div>
+                <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "avwede", rating: 5}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100", user: "avwede", rating: 10}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100", user: "jon", rating: 8}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100", user: "doe", rating: 2}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/6/60/Bad_Bunny_-_Un_Verano_Sin_Ti.png", size: "100", user: "avwede", rating: 5}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "harry", rating: 10}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/7a/Brandi_Carlile_-_In_These_Silent_Days.png", size: "100", user: "avwede", rating: 1}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "niall", rating: 9}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/7/76/Adele_-_30.png", size: "100", user: "avwede", rating: 2}} />
+                    <AlbumReview album={{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100", user: "liam",rating: 10}} />
+                </div>
+            </section>
 
+            <section className="pt-14"> 
                 <Titles title="Reviews from Friends"/>
-                    <Review review={exampleReview}/>
-                    <div className="border-t border-gray-600 max-w-6xl mx-auto" />
-                    <Review review={anotherExample}/>
+                <Review review={exampleReview}/>
+                <div className="border-t border-gray-600 max-w-6xl mx-auto" />
+                <Review review={anotherExample}/>
             </section>
 
             {/* Music News */}
-            <section>
-                <Titles title="News"/>
+            <section className="pt-14">
+                <Titles title="Recent News"/>
                 <NewsCard news={newsInfo}/> 
                 <NewsCard news={grammyNews}/> 
             </section>
 
             {/* Grammy Fun! */}
-            <section>
+            <section className="pt-14">
                 <Titles title="Hello, Grammys"/>
-
                 <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
                     <Album album = {{ img: "https://is2-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/1200x1200bf-60.jpg", size: "100"}} />
                     <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/3/38/Lizzo_-_Special.png", size: "100"}} />
@@ -137,9 +143,25 @@ function Discover() {
                     <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/e/e0/ABBA_-_Voyage.png", size: "100"}} />
                 </div>
                 <p className="max-w-6xl mx-auto pt-2 pb-2">The 2023 Grammy Nominations for Album of the Year.</p>
-                <p className="max-w-6xl mx-auto italic text-gray-500 pb-10">WINNER: Harry's House by Harry Styles. Tyler Johnson, Kid Harpoon & Sammy Witte, producers; Jeremy Hatcher, Oli Jacobs, Nick Lobel, Spike Stent & Sammy Witte, engineers/mixers; Amy Allen, Tobias Jesso, Jr., Tyler Johnson, Kid Harpoon, Mitch Rowland, Harry Styles & Sammy Witte, songwriters; Randy Merrill, mastering engineer.</p>
+                <p className="max-w-6xl mx-auto italic text-gray-500">WINNER: Harry's House by Harry Styles. Tyler Johnson, Kid Harpoon & Sammy Witte, producers; Jeremy Hatcher, Oli Jacobs, Nick Lobel, Spike Stent & Sammy Witte, engineers/mixers; Amy Allen, Tobias Jesso, Jr., Tyler Johnson, Kid Harpoon, Mitch Rowland, Harry Styles & Sammy Witte, songwriters; Randy Merrill, mastering engineer.</p>
             </section>
 
+            <section className="pt-14">
+                <Titles title="Trill Team Favorites"></Titles>
+                    <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
+                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/f/f8/Taylor_Swift_-_Folklore.png", size: "100"}} />
+                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Continuum_by_John_Mayer_%282006%29.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://m.media-amazon.com/images/I/51uCkvt4ZjL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/b/bf/SZA_-_Ctrl_cover.png", size: "100"}} />
+                        <Album album = {{ img: "https://i.scdn.co/image/ab67616d0000b273d58e537cea05c2156792c53d", size: "100"}} />
+                        <Album album = {{ img: "https://m.media-amazon.com/images/I/71+q4wh2+YL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/d/da/Combs_growin_up.jpg/220px-Combs_growin_up.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://m.media-amazon.com/images/I/41kIEeScTiL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://media.pitchfork.com/photos/6380d5021628784965dd6626/1:1/w_600/Phoebe-Bridgers-Stranger-in-the-Alps.jpg", size: "100"}} />
+                        <Album album = {{ img: "https://media.pitchfork.com/photos/5929b665b1335d7bf169aa5e/1:1/w_600/916a09f4.jpg", size: "100"}} />
+                    </div>
+                <p className="max-w-6xl mx-auto text-gray-400 pt-2 pb-10 text-left italic">Our team's top picks.</p>
+            </section>
             </>}
         </div>
     );

--- a/web/src/pages/ListAlbums.jsx
+++ b/web/src/pages/ListAlbums.jsx
@@ -1,7 +1,7 @@
 function ListAlbums() {
     return (
-        <div>
-            Albums List
+        <div className="max-w-5xl mx-auto">
+            <p>List ALbums</p>
         </div>
     );
 }

--- a/web/src/pages/ListenLater.jsx
+++ b/web/src/pages/ListenLater.jsx
@@ -21,13 +21,16 @@ function ListenLater() {
         );
     }
     return (
-        <div className="max-w-6xl mx-auto">            
+        <div className="max-w-6xl mx-auto">           
+
             <h1 className="font-bold text-3xl md:text-4xl text-white text-center pt-[20px] pb-10">Don't miss a beat. Save it for later.</h1>
             
             <Titles title="You want to listen to 50 albums" />
+            
             <div className="text-white flex flex-row flex-wrap justify-center gap-4 max-w-6xl mx-auto">
                 {dummyAlbums}  
             </div>
+
         </div>
     );
 }

--- a/web/src/partials/TeamSection.jsx
+++ b/web/src/partials/TeamSection.jsx
@@ -11,22 +11,24 @@ import Titles from "../components/Titles"
 function TeamSection() {
     return (
         <section className="py-6 text-gray-100">
+            
              <div>
-                    <Titles title="Trill Team Favorites"></Titles>
-                    <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/f/f8/Taylor_Swift_-_Folklore.png", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Continuum_by_John_Mayer_%282006%29.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/51uCkvt4ZjL._UF1000,1000_QL80_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/b/bf/SZA_-_Ctrl_cover.png", size: "100"}} />
-                        <Album album = {{ img: "https://i.scdn.co/image/ab67616d0000b273d58e537cea05c2156792c53d", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/71+q4wh2+YL._UF1000,1000_QL80_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/d/da/Combs_growin_up.jpg/220px-Combs_growin_up.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://m.media-amazon.com/images/I/41kIEeScTiL._UF1000,1000_QL80_.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/6380d5021628784965dd6626/1:1/w_600/Phoebe-Bridgers-Stranger-in-the-Alps.jpg", size: "100"}} />
-                        <Album album = {{ img: "https://media.pitchfork.com/photos/5929b665b1335d7bf169aa5e/1:1/w_600/916a09f4.jpg", size: "100"}} />
-                    </div>
-                    <p className="max-w-6xl mx-auto text-gray-400 pt-2 pb-10 text-left italic">Our team's top picks.</p>
+                <Titles title="Trill Team Favorites"></Titles>
+                <div className="text-white flex flex-row justify-center gap-4 max-w-6xl mx-auto">
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/f/f8/Taylor_Swift_-_Folklore.png", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/commons/0/0e/Continuum_by_John_Mayer_%282006%29.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://m.media-amazon.com/images/I/51uCkvt4ZjL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/b/bf/SZA_-_Ctrl_cover.png", size: "100"}} />
+                    <Album album = {{ img: "https://i.scdn.co/image/ab67616d0000b273d58e537cea05c2156792c53d", size: "100"}} />
+                    <Album album = {{ img: "https://m.media-amazon.com/images/I/71+q4wh2+YL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://upload.wikimedia.org/wikipedia/en/thumb/d/da/Combs_growin_up.jpg/220px-Combs_growin_up.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://m.media-amazon.com/images/I/41kIEeScTiL._UF1000,1000_QL80_.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://media.pitchfork.com/photos/6380d5021628784965dd6626/1:1/w_600/Phoebe-Bridgers-Stranger-in-the-Alps.jpg", size: "100"}} />
+                    <Album album = {{ img: "https://media.pitchfork.com/photos/5929b665b1335d7bf169aa5e/1:1/w_600/916a09f4.jpg", size: "100"}} />
+                </div>
+                <p className="max-w-6xl mx-auto text-gray-400 pt-2 pb-10 text-left italic">Our team's top picks.</p>
             </div>
+
             <div className="container flex flex-col items-center justify-center p-4 mx-auto sm:p-10">
                 <p className="p-2 text-md font-medium tracking-wider text-center uppercase">Development team</p>
                 <h1 className="text-4xl font-bold leading-none text-center sm:text-5xl">The talented people behind the scenes</h1>

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -22,5 +22,6 @@ module.exports = {
   plugins: [
     require("daisyui"),
     require('@tailwindcss/forms'),
+    require('@tailwindcss/line-clamp')
   ],
 }


### PR DESCRIPTION
## Describe your changes
- added "AlbumReview" component that is a shortform preview of a review (and does not show the actual review text). intended purpose is to display similar data, but in a different way on the discover page.
- added state/responsiveness to liking a review
- added overlay of text to album art

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Issue Jira ticket number and link

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
![image](https://user-images.githubusercontent.com/42351353/220429057-8f9a19ea-a6f9-4291-8908-46ccf75a7243.png)
