### PR TITLE
API request changes + documentation

### DIFF
--- a/apis.yaml
+++ b/apis.yaml
@@ -1,0 +1,473 @@
+swagger: '2.0'
+info:
+  description: Click the lock icon to set the access token.
+  version: 1.0.0
+  title: Trill APIs
+
+tags:
+- name: users
+- name: follows
+- name: albums
+- name: reviews
+- name: likes
+  description: review likes
+- name: favorite albums
+
+securityDefinitions:
+  AccessToken:
+    type: apiKey
+    name: Authorization
+    in: header
+    description: >-
+      Enter the token with the `Bearer` prefix, e.g. "Bearer eyJraWQ...".
+
+paths:
+  /users:
+    get:
+      tags:
+      - users
+      description: Get user information based on access token user
+      operationId: getUser
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      responses:
+        200:
+          description: user info
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    put:
+      tags:
+      - users
+      description: Update user bio or profile picture.
+        Note that current implementation returns 200 status code for invalid requests
+      operationId: updateUser
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - in: body
+        name: updateRequest
+        description: Update bio and/or profilePicture
+        schema:
+          $ref: '#/definitions/UpdateUserRequest'
+      responses:
+        200:
+          description: success
+        400:
+          description: invalid request body
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /follows:
+    get:
+      tags:
+      - follows
+      operationId: getFollows
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: type
+        in: query
+        description: getFollowers or getFollowing
+        required: true
+        default: getFollowers
+        type: string
+      - name: username
+        in: query
+        required: true
+        type: string
+        default: cathychian
+      responses:
+        200:
+          description: list of followers or following
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    post:
+      tags:
+      - follows
+      operationId: createFollow
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - in: query
+        name: username
+        description: user to follow
+        type: string
+        default: cathychian
+      responses:
+        201:
+          description: follow added to database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    delete:
+      tags:
+      - follows
+      operationId: deleteFollow
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - in: query
+        name: username
+        description: user to unfollow
+        type: string
+        default: cathychian
+      responses:
+        200:
+          description: follow deleted from database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /album:
+    get:
+      tags:
+      - albums
+      operationId: getAlbum
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: albumID
+        in: query
+        description: Spotify album ID
+        required: true
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+        type: string
+      responses:
+        200:
+          description: success
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /albums:
+    get:
+      tags:
+      - albums
+      operationId: getAlbums
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: query
+        in: query
+        description: Search query
+        required: true
+        default: speak now
+        type: string
+      responses:
+        200:
+          description: success
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /reviews:
+    get:
+      tags:
+      - reviews
+      operationId: getReview
+      description: Specify sort to get all reviews for album. Specify username to get user's review for album.
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: albumID
+        in: query
+        description: Spotify album ID
+        required: true
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+        type: string
+      - name: sort
+        description: popular, newest, or oldest
+        in: query
+        type: string
+        default: popular
+      - name: username
+        in: query
+        type: string
+      responses:
+        200:
+          description: success
+        204:
+          description: no content
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    put:
+      tags:
+      - reviews
+      operationId: createReview
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: albumID
+        in: query
+        required: true
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+        type: string
+      - in: body
+        name: reviewRequest
+        description: review_text is optional
+        schema:
+          $ref: '#/definitions/CreateReview'
+      responses:
+        201:
+          description: added to database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    delete:
+      tags:
+      - reviews
+      operationId: deleteReview
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: albumID
+        in: query
+        required: true
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+        type: string
+      responses:
+        200:
+          description: deleted from database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /likes:
+    get:
+      tags:
+      - likes
+      operationId: getLikeCount
+      description: Get like count for review
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: reviewID
+        in: query
+        required: true
+        default: 789
+        type: string
+      responses:
+        200:
+          description: success
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    put:
+      tags:
+      - likes
+      operationId: likeReview
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: reviewID
+        in: query
+        required: true
+        default: 789
+        type: string
+      responses:
+        201:
+          description: added to database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    delete:
+      tags:
+      - likes
+      operationId: unlikeReview
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: reviewID
+        in: query
+        required: true
+        default: 789
+        type: string
+      responses:
+        200:
+          description: deleted from database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+  /favoritealbums:
+    get:
+      tags:
+      - favorite albums
+      operationId: getFavoriteAlbums
+      produces:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - name: username
+        in: query
+        required: true
+        default: cathychian
+        type: string
+      responses:
+        200:
+          description: success
+        204:
+          description: no favorite albums
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    post:
+      tags:
+      - favorite albums
+      operationId: addFavoriteAlbums
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - in: query
+        name: albumID
+        description: Spotify album ID
+        type: string
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+      responses:
+        201:
+          description: added to database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+    delete:
+      tags:
+      - favorite albums
+      operationId: deleteFavoriteAlbums
+      consumes:
+      - application/json
+      security:
+      - AccessToken: []
+      parameters:
+      - in: query
+        name: albumID
+        description: Spotify album ID
+        type: string
+        default: 4aawyAB9vmqN3uQ7FjRGTy
+      responses:
+        200:
+          description: deleted from database
+        400:
+          description: invalid request
+        403:
+          description: forbidden
+        405:
+          description: invalid http method
+        500:
+          description: error
+          
+definitions:
+  UpdateUserRequest:
+    type: object
+    required:
+    - bio
+    - profilePicture
+    properties:
+      bio:
+        type: string
+        example: "this is my bio"
+      profilePicture:
+        type: string
+        example: "idk the format but uh yeah"
+  CreateReview:
+    type: object
+    required:
+    - rating
+    - review_text
+    properties:
+      rating:
+        type: integer
+        example: 7
+      review_text:
+        type: string
+        example: "i hated it"
+
+host: api.trytrill.com
+basePath: /main
+schemes:
+ - https

--- a/backend/src/handlers/follows/main.go
+++ b/backend/src/handlers/follows/main.go
@@ -64,12 +64,12 @@ func follow(ctx context.Context, req events.APIGatewayV2HTTPRequest) (Response, 
 		return Response{StatusCode: 500, Body: "User cannot follow themselves", Headers: views.DefaultHeaders}, nil
 	}
 
-	follows := models.Follows{
+	follow := models.Follows{
 		Followee:  username,
 		Following: userToFollow,
 	}
 
-	if err := models.CreateFollow(ctx, &follows); err != nil {
+	if err := models.CreateFollow(ctx, &follow); err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
 
@@ -151,12 +151,12 @@ func unfollow(ctx context.Context, req events.APIGatewayV2HTTPRequest) (Response
 		return Response{StatusCode: 500, Body: "User cannot unfollow themselves", Headers: views.DefaultHeaders}, nil
 	}
 
-	follows := models.Follows{
+	follow := models.Follows{
 		Followee:  username,
 		Following: userToUnfollow,
 	}
 
-	if err := models.DeleteFollow(ctx, &follows); err != nil {
+	if err := models.DeleteFollow(ctx, &follow); err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
 

--- a/backend/src/models/albums.go
+++ b/backend/src/models/albums.go
@@ -16,7 +16,8 @@ func GetFavoriteAlbums(ctx context.Context, username string) (*[]FavoriteAlbum, 
 	}
 
 	var favoriteAlbums []FavoriteAlbum
-	if err := db.Table("favorite_albums").Where("username = ?", username).Find(&favoriteAlbums).Error; err != nil {
+	result := db.Where("username = ?", username).Find(&favoriteAlbums)
+	if err := result.Error; err != nil {
 		return nil, err
 	}
 

--- a/backend/src/models/follows.go
+++ b/backend/src/models/follows.go
@@ -37,7 +37,7 @@ func GetFollowers(ctx context.Context, followee string) (*[]Follows, error) {
 	return &followers, nil
 }
 
-func CreateFollows(ctx context.Context, follows *Follows) error {
+func CreateFollow(ctx context.Context, follows *Follows) error {
 	if db, err := GetDBFromContext(ctx); err != nil {
 		return err
 	} else if err := db.Create(&follows).Error; err != nil {
@@ -47,7 +47,7 @@ func CreateFollows(ctx context.Context, follows *Follows) error {
 	return nil
 }
 
-func DeleteFollows(ctx context.Context, follows *Follows) error {
+func DeleteFollow(ctx context.Context, follows *Follows) error {
 	if db, err := GetDBFromContext(ctx); err != nil {
 		return err
 	} else if err := db.Where("followee = ? AND following = ?", follows.Followee, follows.Following).Delete(follows).Error; err != nil {

--- a/backend/src/views/albums.go
+++ b/backend/src/views/albums.go
@@ -53,6 +53,8 @@ type SpotifyError struct {
 }
 
 type FavoriteAlbum struct {
+	Username string `json:"username"`
+	AlbumID  string `json:"album_id"`
 }
 
 func MarshalSpotifyAlbum(ctx context.Context, unmarshalledSpotifyAlbum *SpotifyAlbum) (string, error) {


### PR DESCRIPTION
- Instead of passing in the username in the request body, create and delete APIs now use the username from the access token
  - The body is now replaced by a query parameter since there's generally just one field
- All query parameters are now in camel case
- Fixed delete follow API
- Fixed some status codes

All changes are documented in SwaggerHub: https://app.swaggerhub.com/apis/CathyChian/Trill/1.0.0
- Can try sending requests to all existing APIs easily
- Since I can't add editors to SwaggerHub: added apis.yaml, so if you change an API, document the change in that file