### PR TITLE
TSD-174: added user search

### DIFF
--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -104,6 +104,21 @@ func GetUser(ctx context.Context, username string) (*User, error) {
 	return &user, nil
 }
 
+func SearchUser(ctx context.Context, username string) (*[]User, error) {
+	db, err := GetDBFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []User
+	// if err := db.Where("SOUNDEX(username) = SOUNDEX(?)", username).Limit(50).Find(&users).Error; err != nil {
+	// if err := db.Where("MATCH(username) AGAINST(? IN BOOLEAN MODE)", searchTerm).Limit(50).Find(&users).Error; err != nil {
+	if err := db.Where("username LIKE ?", "%"+username+"%").Find(&users).Error; err != nil {
+		return nil, err
+	}
+	return &users, nil
+}
+
 func UpdateUser(ctx context.Context, user *User) error {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {

--- a/backend/src/views/users.go
+++ b/backend/src/views/users.go
@@ -14,7 +14,7 @@ type User struct {
 }
 
 // Combines the two JSON's to one string
-func MarshalUser(ctx context.Context, userModel *models.User, publicCognitoUserModel *models.PublicCognitoUser,
+func MarshalFullUser(ctx context.Context, userModel *models.User, publicCognitoUserModel *models.PublicCognitoUser,
 	privateCognitoUserModel *models.PrivateCognitoUser) (string, error) {
 	user := User{
 		Username:       userModel.Username,
@@ -25,6 +25,10 @@ func MarshalUser(ctx context.Context, userModel *models.User, publicCognitoUserM
 	}
 
 	return Marshal(ctx, user)
+}
+
+func MarshalUsers(ctx context.Context, userModels *[]models.User) (string, error) {
+	return Marshal(ctx, userModels)
 }
 
 func UnmarshalUser(ctx context.Context, marshalledUser string, userModel *models.User) error {


### PR DESCRIPTION
## Describe your changes

Added a new endpoint to facilitate searching for users. Unfortunately, MySQL does not come with a suitable fuzzy _word_ searching method out of the box (`MATCH AGAINST` doesn't really work for our use case), so substring searching using `LIKE` is the next best thing and is what was implemented.

This also currently does not return their nickname, though this can be added if necessary.

**Testing Cases:**
_Users_
`/users?search={username substring}` - GET
- 200: List of users whose username contains substring is returned :heavy_check_mark:
- 200: Empty list is returned if no matches are found :heavy_check_mark: 

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

TSD-174

## Issue Jira ticket number and link

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
