### PR TITLE
Add skeleton components for Album Details page

### DIFF
--- a/web/src/components/AlbumDetailsReview.jsx
+++ b/web/src/components/AlbumDetailsReview.jsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+// Components
+import Album from "../components/Album"
+import Avatar from "../components/Avatar"
+import Stars from "../components/Stars"
+
+// Icons
+import Heart from '/heart.svg';
+
+function AlbumDetailsReview(props) {
+    const { user, profilePic, rating, review, name: albumName, release_date: albumYear, artists: artist } = props.review;
+
+    const [isLiked, setIsLiked] = useState(false);
+
+    const handleLikeClick = () => {
+        setIsLiked(!isLiked);
+    }
+
+    return (
+        <div className="max-w-6xl mx-auto">
+
+            <div className="flex flex-row p-5">
+                <Avatar user={{ profilePic: profilePic, firstName: "Ashley", size: "12" }} />
+
+                <div className="flex flex-col pl-5 gap-4">
+                    {/* Profile Picture, Rating, and Listen Date */}
+                    <div className="flex flex-row gap-4 text-md">
+                        <p className="text-gray-500">Review by
+                            <span className="text-gray-400 font-bold"> {user} </span>
+                        </p>
+                        <Stars rating={ rating } />
+                    </div>
+
+                    {/* Review */}
+                    <p className="text-md pb-4">{review}</p>
+                    <div className="flex flex-row gap-2 text-gray-500 text-sm">
+                        <div
+                        onClick={handleLikeClick}
+                        className="flex gap-1 items-center transition duration-300 ease-in-out hover:text-gray-400 cursor-pointer font-bold"
+                        >
+                            <p className={`${isLiked ? 'text-red-500' : 'text-gray-500'}`}>
+                                ❤︎
+                            </p>
+
+                            <p className={`${isLiked ? 'text-gray-300' : ''}`}>
+                                {isLiked ? 'Liked' : 'Like review'}
+                            </p>
+                        </div>
+                        <p>2000 likes</p>
+                    </div>
+                </div>
+                
+            </div>
+        </div>
+    );
+}
+
+export default AlbumDetailsReview;

--- a/web/src/components/Avatar.jsx
+++ b/web/src/components/Avatar.jsx
@@ -16,6 +16,7 @@ const AvatarComp = (props) =>{
         </div>
     );
 }
+
 function Avatar(props) {
     const {firstName, linkDisabled} = props.user;
     return (

--- a/web/src/components/AvgReviews.jsx
+++ b/web/src/components/AvgReviews.jsx
@@ -2,52 +2,52 @@ import Stars from "../components/Stars"
 
 function AvgReviews() {
     return (
-        <div className="flex flex-col max-w-sm p-5 shadow-sm rounded-xl bg-gray-600 text-gray-100 mx-auto">
+        <div className="flex flex-col max-w-xl p-4 shadow-sm rounded-xl bg-[#383b59] text-gray-100">
             <div className="flex flex-col w-full">
-                <h2 className="text-2xl font-bold text-center px-14">Average Ratings</h2>
+                <h2 className="px-20 text-xl text-center pb-1 text-gray-200">Average Rating</h2>
+                <p className="text-3xl mx-auto font-bold">9.8</p>  
 
-                {/* Average Stars out of 5 */}
-                <div className="flex text-2xl mx-auto">
-                    <Stars rating={5} />
+                <div className="flex text-xl mx-auto">
+                    <Stars rating={10} />
                 </div>
+                
+                <p className="text-sm italic text-gray-300 mx-auto pb-3">74 global ratings</p>
 
-                <p className="text-md italic text-gray-400 mx-auto">74 Reviews Total</p>
-
-                <div className="flex flex-col mt-2">
+                <div className="flex flex-col">
                     <div className="flex items-center space-x-1">
-                        <span className="flex-shrink-0 w-12 text-sm">5 star</span>
-                        <div className="flex-1 h-4 overflow-hidden rounded-sm dark:bg-gray-700">
+                        <span className="flex-shrink-0 w-12 text-sm text-gray-200">5 star</span>
+                        <div className="flex-1 h-4 overflow-hidden rounded-sm bg-gray-600">
                             <div className="bg-trillBlue h-4 w-5/6"></div>
                         </div>
-                        <span className="flex-shrink-0 w-12 text-sm text-right">83%</span>
+                        <span className="flex-shrink-0 w-12 text-sm text-right text-gray-200">83%</span>
                     </div>
                     <div className="flex items-center space-x-1">
-                        <span className="flex-shrink-0 w-12 text-sm">4 star</span>
-                        <div className="flex-1 h-4 overflow-hidden rounded-sm dark:bg-gray-700">
+                        <span className="flex-shrink-0 w-12 text-sm text-gray-200">4 star</span>
+                        <div className="flex-1 h-4 overflow-hidden rounded-sm bg-gray-600">
                             <div className="bg-trillBlue h-4 w-4/6"></div>
                         </div>
-                        <span className="flex-shrink-0 w-12 text-sm text-right">67%</span>
+                        <span className="flex-shrink-0 w-12 text-sm text-right text-gray-200">67%</span>
                     </div>
                     <div className="flex items-center space-x-1">
-                        <span className="flex-shrink-0 w-12 text-sm">3 star</span>
-                        <div className="flex-1 h-4 overflow-hidden rounded-sm dark:bg-gray-700">
+                        <span className="flex-shrink-0 w-12 text-sm text-gray-200">3 star</span>
+                        <div className="flex-1 h-4 overflow-hidden rounded-sm bg-gray-600">
                             <div className="bg-trillBlue h-4 w-3/6"></div>
                         </div>
-                        <span className="flex-shrink-0 w-12 text-sm text-right">50%</span>
+                        <span className="flex-shrink-0 w-12 text-sm text-right text-gray-200">50%</span>
                     </div>
                     <div className="flex items-center space-x-1">
-                        <span className="flex-shrink-0 w-12 text-sm">2 star</span>
-                        <div className="flex-1 h-4 overflow-hidden rounded-sm dark:bg-gray-700">
+                        <span className="flex-shrink-0 w-12 text-sm text-gray-200">2 star</span>
+                        <div className="flex-1 h-4 overflow-hidden rounded-sm bg-gray-600">
                             <div className="bg-trillBlue h-4 w-2/6"></div>
                         </div>
-                        <span className="flex-shrink-0 w-12 text-sm text-right">33%</span>
+                        <span className="flex-shrink-0 w-12 text-sm text-right text-gray-200">33%</span>
                     </div>
                     <div className="flex items-center space-x-1">
-                        <span className="flex-shrink-0 w-12 text-sm">1 star</span>
-                        <div className="flex-1 h-4 overflow-hidden rounded-sm dark:bg-gray-700">
+                        <span className="flex-shrink-0 w-12 text-sm text-gray-200">1 star</span>
+                        <div className="flex-1 h-4 overflow-hidden rounded-sm bg-gray-600">
                             <div className="bg-trillBlue h-4 w-1/6"></div>
                         </div>
-                        <span className="flex-shrink-0 w-12 text-sm text-right">17%</span>
+                        <span className="flex-shrink-0 w-12 text-sm text-right text-gray-200">17%</span>
                     </div>
                 </div>
             </div>

--- a/web/src/components/Titles.jsx
+++ b/web/src/components/Titles.jsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
-import ArrowRightIcon from '@mui/icons-material/ArrowRight';
+// import { Link } from "react-router-dom";
+// import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 
 function Titles(props) {
     return (
@@ -7,12 +7,12 @@ function Titles(props) {
             <div className="flex max-w-6xl mx-auto justify-between text-gray-400 pr-1 pl-1">
                 {props.title}
 
-                {props.title === "Recent News" ? "" : 
+                {/* {props.title === "Recent News" ? "" : 
                     <Link to="/User/More">
                         More <ArrowRightIcon />
                     </Link> 
                 }
-                
+                 */}
             </div>
 
             <div className="border-t border-gray-400 pt-5 max-w-6xl mx-auto" />

--- a/web/src/pages/AlbumDetails.jsx
+++ b/web/src/pages/AlbumDetails.jsx
@@ -1,5 +1,9 @@
-import AvgReviews from "../components/AvgReviews";
 import { useLocation } from "react-router-dom";
+
+// Components
+import AvgReviews from "../components/AvgReviews";
+import Titles from "../components/Titles"
+import AlbumDetailsReview from "../components/AlbumDetailsReview"
 
 function AlbumDetails() {
     // IMAGE URL
@@ -60,38 +64,61 @@ function AlbumDetails() {
         ],
     }
 
+    let albumDummy = { 
+        "images": [{"url": "https://i.scdn.co/image/ab67616d0000b2732e8ed79e177ff6011076f5f0"}], 
+        "name": "Harry's House",
+        "artists": [
+            {
+                "name": "Harry Styles"
+            }
+        ],
+        "external_urls": {
+            "spotify": "https://open.spotify.com/album/5r36AJ6VOJtp00oxSkBZ5h"
+        },
+        "release_date": "2021",
+        "size": "150"
+    };
+
+    let reviewDummy = {
+        ...albumDummy,
+        user: "Ligma Johnson",
+        profilePic: "https://www.meme-arsenal.com/memes/be23686a25bc2d9b52a04ebdf6e4f280.jpg",
+        review: "Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.Harry has done it yet again.",
+        rating: 5,
+    };
+
     return (
         <div className="max-w-6xl mx-auto">
-            <div className="relative">
-                {/* Background Artist Image */}
-                <div className="flex justify-center">
-                    <div className="w-full h-96 overflow-hidden">
-                        <div className="relative h-full">
-                            <img className="object-cover w-full h-full opacity-50 rounded-b-xl z-0" 
-                                src={exampleAlbum.artists[0].images[0].url} alt="Album Cover" 
-                            />
-                        </div>
-                        <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-t from-trillPurple via-trillPurple to-transparent"></div>
+
+            {/* Background Artist Image Section*/}
+            <div className="flex justify-center">
+                <div className="w-full h-96 overflow-hidden">
+                    <div className="h-full">
+                        <img className="object-cover w-full h-full opacity-25 rounded-b-xl z-0" 
+                            src={exampleAlbum.artists[0].images[0].url} alt="Album Cover" 
+                        />
                     </div>
                 </div>
+            </div>
 
-                {/* Album Art Image */}
-                <div className="flex flex-row z-10 justify-left items-start">
+            <div className="flex flex-row mx-auto justify-between pt-10">
+                {/* Album Art Image and Details Section */}
+                <div className="flex flex-row z-10">
 
-                    <div className="z-10">
-                        { img[0] ? 
-                            <img className="w-40 h-40" src={img[0].url} alt="Album Overlay Image" />
-                        : 
-                            // If url image doesn't exist, populate with text
-                            <div className={`w-40 h-40 flex items-center justify-center text-gray-200 bg-gray-700 ring-2 ring-gray-500`}>
-                                <p className="text-xs text-center max-w-full line-clamp-2">{ name || "Click for album details" }</p>
-                            </div>
-                        }
+                    <div className="flex flex-col">
+                            { img[0] ? 
+                                <img className="w-64 h-64" src={img[0].url} alt="Album Image" />
+                            : 
+                                <div className={`w-64 h-64 flex items-center justify-center text-gray-200 bg-gray-700 ring-2 ring-gray-500`}>
+                                    <p className="text-xs text-center max-w-full line-clamp-2">{ name || "Click for album details" }</p>
+                                </div>
+                            }
+                            <button className="btn btn-xs bg-[#383b59] hover:bg-trillBlue hover:text-black mt-2">Add Review</button>
+                            <button className="btn btn-xs bg-[#383b59] hover:bg-trillBlue hover:text-black mt-2">Add to Listen Later</button>
                     </div>
-
+                    
                     <div className="z-10 pl-10 flex flex-row gap-10">
                         <div className="flex flex-col">
-                            {/* Album Name and Year Released */}
                             <div className="flex flex-row gap-4">
                                 <h1 className="text-3xl text-gray-200">
                                     <span className="font-bold italic">{name}</span> 
@@ -99,12 +126,45 @@ function AlbumDetails() {
                                 <h1 className="text-3xl text-gray-500">{year.split('-')[0]}</h1>
                             </div>
 
-                            {/* Artist Name */}
-                            <p className="text-lg">by {artist[0].name}</p>
+                            <p className="text-xl pt-1">by {artist[0].name}</p>
+
                         </div>
                     </div>
-                    
                 </div>    
+
+                {/* Average Reviews Section */}
+                <div className="z-10">
+                    <AvgReviews />
+                </div>
+            </div>
+
+            {/* Review Section */}
+            <div className="pt-10">
+                <div className="pt-10">
+                    <Titles title="Reviews From Friends" />
+                    <AlbumDetailsReview review={ reviewDummy } />
+                    <div className="border-t border-gray-600 max-w-6xl mx-auto" />
+                    <AlbumDetailsReview review={ reviewDummy }/>
+                </div>
+
+                <div className="pt-10">
+                    <Titles title="Popular Reviews" />
+                    <AlbumDetailsReview review={ reviewDummy } />
+                    <div className="border-t border-gray-600 max-w-6xl mx-auto" />
+                    <AlbumDetailsReview review={ reviewDummy }/>
+                </div>
+
+                <div className="pt-10">
+                    <Titles title="Recent Reviews" />
+                    <AlbumDetailsReview review={ reviewDummy } />
+                    <div className="border-t border-gray-600 max-w-6xl mx-auto" />
+                    <AlbumDetailsReview review={ reviewDummy }/>
+                </div>
+
+                <div className="pt-10">
+                    <Titles title="Your Review" />
+                    <AlbumDetailsReview review={ reviewDummy } />
+                </div>
             </div>
             
         </div>


### PR DESCRIPTION
## Describe your changes
- more work on album details
- the mask over the cover photo was super buggy so i removed that for now. will revisit later
- created a new, specific album details review component. this one does not show the album info since you're on the specific album page

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Issue Jira ticket number and link

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
![image](https://user-images.githubusercontent.com/42351353/222633393-ea0a4d38-159c-4c7f-80a6-6825812de8b1.png)
