### PR TITLE
Create/Update Review API Fix

### DIFF
--- a/backend/src/models/reviews.go
+++ b/backend/src/models/reviews.go
@@ -14,7 +14,7 @@ type Review struct {
 	Username   string
 	AlbumID    string
 	Rating     int
-	ReviewText string
+	ReviewText string    `json:"review_text"`
 	CreatedAt  time.Time `gorm:"default:CURRENT_TIMESTAMP"`
 	UpdatedAt  time.Time `gorm:"default:CURRENT_TIMESTAMP"`
 	Likes      []Like    `gorm:"foreignKey:ReviewID;references:ReviewID;constraint:OnDelete:CASCADE;"`


### PR DESCRIPTION
Currently, creating/updating a review isn't unmarshalling the `review_text` and adding it into the database.

I think all the models should theoretically have JSON tags for consistency, but we haven't faced this issue earlier since most of the fields in our API request bodies are just one word and don't have underscores.