### PR TITLE
TSD 169

### DIFF
--- a/backend/src/handlers/follows/main.go
+++ b/backend/src/handlers/follows/main.go
@@ -94,7 +94,7 @@ func getFollowing(ctx context.Context, req events.APIGatewayV2HTTPRequest) (Resp
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
 
-	body, err := views.MarshalFollowing(ctx, following)
+	body, err := views.MarshalUsers(ctx, following)
 	if err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
@@ -120,7 +120,7 @@ func getFollowers(ctx context.Context, req events.APIGatewayV2HTTPRequest) (Resp
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
 
-	body, err := views.MarshalFollowers(ctx, followers)
+	body, err := views.MarshalUsers(ctx, followers)
 	if err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}

--- a/backend/src/handlers/reviews/main.go
+++ b/backend/src/handlers/reviews/main.go
@@ -108,7 +108,6 @@ func getReviews(ctx context.Context, req Request) (Response, error) {
 		return Response{StatusCode: 500, Body: ErrorSort.Error(), Headers: views.DefaultHeaders}, nil
 	}
 
-	var followingModels *[]models.Follows = nil
 	reviewQuery := models.Review{
 		Username: func() string {
 			if hasUserParam {
@@ -119,9 +118,10 @@ func getReviews(ctx context.Context, req Request) (Response, error) {
 		AlbumID: albumID,
 	}
 
+	var users *[]models.User = nil
 	if following {
 		var err error
-		followingModels, err = models.GetFollowing(ctx, requestor)
+		users, err = models.GetFollowing(ctx, requestor)
 		if err != nil {
 			return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 		}
@@ -135,7 +135,7 @@ func getReviews(ctx context.Context, req Request) (Response, error) {
 	case "oldest":
 		fallthrough
 	case "popular":
-		reviews, err = models.GetReviews(ctx, &reviewQuery, followingModels, sort)
+		reviews, err = models.GetReviews(ctx, &reviewQuery, users, sort)
 		if err != nil {
 			return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 		}

--- a/backend/src/handlers/usersCognito/main.go
+++ b/backend/src/handlers/usersCognito/main.go
@@ -26,6 +26,7 @@ func create(ctx context.Context, req CognitoEvent) (CognitoEvent, error) {
 
 	user := models.User{
 		Username:       req.UserName,
+		Nickname:       req.Request.UserAttributes["nickname"],
 		Bio:            "",
 		ProfilePicture: "",
 	}

--- a/backend/src/models/follows.go
+++ b/backend/src/models/follows.go
@@ -9,7 +9,8 @@ type Follows struct {
 	Following string `gorm:"foreignKey:Username"`
 }
 
-func GetFollowing(ctx context.Context, followee string) (*[]Follows, error) {
+// TODO consolidate GetFollowing and GetFollowers
+func GetFollowing(ctx context.Context, followee string) (*[]User, error) {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -20,10 +21,19 @@ func GetFollowing(ctx context.Context, followee string) (*[]Follows, error) {
 		return nil, err
 	}
 
-	return &following, nil
+	usernames := make([]string, len(following))
+	for i, f := range following {
+		usernames[i] = f.Following
+	}
+	users, err := GetUsers(ctx, usernames)
+	if err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }
 
-func GetFollowers(ctx context.Context, followee string) (*[]Follows, error) {
+func GetFollowers(ctx context.Context, followee string) (*[]User, error) {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -34,7 +44,16 @@ func GetFollowers(ctx context.Context, followee string) (*[]Follows, error) {
 		return nil, err
 	}
 
-	return &followers, nil
+	usernames := make([]string, len(followers))
+	for i, f := range followers {
+		usernames[i] = f.Followee
+	}
+	users, err := GetUsers(ctx, usernames)
+	if err != nil {
+		return nil, err
+	}
+
+	return users, nil
 }
 
 func CreateFollow(ctx context.Context, follows *Follows) error {

--- a/backend/src/models/reviews.go
+++ b/backend/src/models/reviews.go
@@ -41,7 +41,7 @@ func GetReview(ctx context.Context, username string, albumID string) (*Review, e
 	}
 }
 
-func GetReviews(ctx context.Context, review *Review, following *[]Follows, sort string) (*[]Review, error) {
+func GetReviews(ctx context.Context, review *Review, following *[]User, sort string) (*[]Review, error) {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -54,11 +54,11 @@ func GetReviews(ctx context.Context, review *Review, following *[]Follows, sort 
 
 	query := make(map[string]interface{})
 	if following != nil {
-		followingUsernames := make([]string, len(*following))
+		usernames := make([]string, len(*following))
 		for i, f := range *following {
-			followingUsernames[i] = f.Following
+			usernames[i] = f.Username
 		}
-		query[fmt.Sprintf("%susername", prepend)] = followingUsernames
+		query[fmt.Sprintf("%susername", prepend)] = usernames
 	}
 
 	if len(review.AlbumID) != 0 {

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -80,7 +80,7 @@ func GetUsers(ctx context.Context, usernames []string) (*[]User, error) {
 	}
 
 	var users []User
-	if err := db.Where("name IN ?", usernames).Find(&users).Error; err != nil {
+	if err := db.Where("username IN ?", usernames).Find(&users).Error; err != nil {
 		return nil, err
 	}
 

--- a/backend/src/models/users.go
+++ b/backend/src/models/users.go
@@ -7,13 +7,8 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
-	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"gorm.io/gorm"
 )
-
-type PublicCognitoUser struct {
-	Nickname string
-}
 
 type PrivateCognitoUser struct {
 	Email string
@@ -21,41 +16,9 @@ type PrivateCognitoUser struct {
 
 type User struct {
 	Username       string `json:"username" gorm:"varchar(128);primarykey"`
+	Nickname       string `json:"nickname" gorm:"varchar(128)"`
 	Bio            string `json:"bio" gorm:"varchar(1024)"`
 	ProfilePicture string `json:"profile_picture" gorm:"varchar(512)"`
-}
-
-func GetPublicCognitoUser(ctx context.Context, username string) (*PublicCognitoUser, error) {
-	cognitoClient, err := InitCognitoClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	cognitoUserInput := cognitoidentityprovider.AdminGetUserInput{
-		UserPoolId: &cognitoClient.UserPoolId,
-		Username:   &username,
-	}
-
-	cogInfo, err := cognitoClient.Client.AdminGetUser(ctx, &cognitoUserInput)
-	if err != nil {
-		return nil, err
-	}
-
-	// get email from user attributes
-	nickname := ""
-	for _, v := range cogInfo.UserAttributes {
-		if *v.Name == "nickname" {
-			nickname = *v.Value
-		}
-	}
-
-	if len(nickname) == 0 {
-		return nil, errors.New("could not find user nickname")
-	}
-
-	return &PublicCognitoUser{
-		Nickname: nickname,
-	}, nil
 }
 
 func GetPrivateCognitoUser(ctx context.Context, authToken string) (*PrivateCognitoUser, error) {
@@ -110,6 +73,20 @@ func GetUser(ctx context.Context, username string) (*User, error) {
 	return &user, nil
 }
 
+func GetUsers(ctx context.Context, usernames []string) (*[]User, error) {
+	db, err := GetDBFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []User
+	if err := db.Where("name IN ?", usernames).Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	return &users, nil
+}
+
 func SearchUser(ctx context.Context, username string) (*[]User, error) {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {
@@ -134,28 +111,6 @@ func UpdateUser(ctx context.Context, user *User) error {
 	updatedUser := db.Save(&user)
 	if updatedUser.Error != nil {
 		return updatedUser.Error
-	}
-
-	return nil
-}
-
-func UpdatePublicCognitoUser(ctx context.Context, user *PublicCognitoUser, authToken string) error {
-	cognitoClient, err := InitCognitoClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	userAttributes := make([]types.AttributeType, 1)
-	key := "nickname"
-	userAttributes[0] = types.AttributeType{Name: &key, Value: &user.Nickname}
-	cognitoUserInput := cognitoidentityprovider.UpdateUserAttributesInput{
-		AccessToken:    &authToken,
-		UserAttributes: userAttributes,
-	}
-
-	_, err = cognitoClient.Client.UpdateUserAttributes(ctx, &cognitoUserInput)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/backend/src/views/follows.go
+++ b/backend/src/views/follows.go
@@ -9,30 +9,6 @@ type Follows struct {
 	Users []string `json:"users"`
 }
 
-func MarshalFollowing(ctx context.Context, followsModel *[]models.Follows) (string, error) {
-	following := make([]string, len(*followsModel))
-	for i, f := range *followsModel {
-		following[i] = f.Following
-	}
-	follows := Follows{
-		Users: following,
-	}
-
-	return Marshal(ctx, follows)
-}
-
-func MarshalFollowers(ctx context.Context, followsModel *[]models.Follows) (string, error) {
-	followers := make([]string, len(*followsModel))
-	for i, f := range *followsModel {
-		followers[i] = f.Followee
-	}
-	follows := Follows{
-		Users: followers,
-	}
-
-	return Marshal(ctx, follows)
-}
-
 func UnmarshalFollows(ctx context.Context, marshalledFollows string, followsModel *models.Follows) error {
 	return Unmarshal(ctx, marshalledFollows, followsModel)
 }

--- a/backend/src/views/users.go
+++ b/backend/src/views/users.go
@@ -9,7 +9,7 @@ type User struct {
 	Username       string `json:"username"`
 	Bio            string `json:"bio"`
 	Email          string `json:"email,omitempty"`
-	Nickname       string `json:"nickname,omitempty"`
+	Nickname       string `json:"nickname"`
 	ProfilePicture string `json:"profile_picture"`
 }
 

--- a/backend/src/views/users.go
+++ b/backend/src/views/users.go
@@ -14,14 +14,13 @@ type User struct {
 }
 
 // Combines the two JSON's to one string
-func MarshalFullUser(ctx context.Context, userModel *models.User, publicCognitoUserModel *models.PublicCognitoUser,
-	privateCognitoUserModel *models.PrivateCognitoUser) (string, error) {
+func MarshalFullUser(ctx context.Context, userModel *models.User, privateCognitoUserModel *models.PrivateCognitoUser) (string, error) {
 	user := User{
 		Username:       userModel.Username,
+		Nickname:       userModel.Nickname,
 		Bio:            userModel.Bio,
-		Email:          privateCognitoUserModel.Email,
-		Nickname:       publicCognitoUserModel.Nickname,
 		ProfilePicture: userModel.ProfilePicture,
+		Email:          privateCognitoUserModel.Email,
 	}
 
 	return Marshal(ctx, user)
@@ -33,8 +32,4 @@ func MarshalUsers(ctx context.Context, userModels *[]models.User) (string, error
 
 func UnmarshalUser(ctx context.Context, marshalledUser string, userModel *models.User) error {
 	return Unmarshal(ctx, marshalledUser, userModel)
-}
-
-func UnmarshalPublicCognitoUser(ctx context.Context, marshalledPublicCognitoUser string, publicCognitoUserModel *models.PublicCognitoUser) error {
-	return Unmarshal(ctx, marshalledPublicCognitoUser, publicCognitoUserModel)
 }


### PR DESCRIPTION
## Describe your changes

This is essentially a small refactor of the `Follows` model/view layers. Now, instead of returning rather nondescript `Follows` objects, arrays of `User`s are returned in most circumstances. 

Thus, this addresses TSD-169 directly by providing said `User`s objects in the response for the GET follows endpoint.

Additionally, nicknames are (finally) included in `User` objects, and `PublicCognitoUser` is no more.

**Testing Cases:**
`/users?username={username}` - GET

- 200: Nickname is also returned in response :heavy_check_mark: 

`/users?username={username}` - PUT

- 200: Nickname is successfully updated when provided in request body :heavy_check_mark: 

`/follows?username={username}` - GET

- 200: A user's followers (or following) are now returned in `User` object form :heavy_check_mark: 

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Issue Jira ticket number and link

TSD-169

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
