### PR TITLE
Tsd 178 get global popular

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,14 +7,14 @@
 
 # ifeq ($(SUBDIRS),)
 # $(shell echo $(SUBDIRS))
-SUBDIRS := $(filter-out handlers,$(wildcard src/handlers/*))
+SUBDIRS := $(wildcard src/handlers/*/)
 BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 # endif
 
 build: $(SUBDIRS)
 
 $(SUBDIRS):
-	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/$(@F) $@/main.go
+	env GOARCH=amd64 GOOS=linux CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/$(patsubst src/handlers/%/,%, $@) $@main.go
 
 clean: 
 	rm -rf ./bin

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,7 +7,7 @@
 
 # ifeq ($(SUBDIRS),)
 # $(shell echo $(SUBDIRS))
-SUBDIRS := $(wildcard src/handlers/*)
+SUBDIRS := $(filter-out handlers,$(wildcard src/handlers/*))
 BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 # endif
 

--- a/backend/apis.yaml
+++ b/backend/apis.yaml
@@ -198,6 +198,11 @@ paths:
         description: Search query (leave blank for most popular albums over past week)
         default: speak now
         type: string
+      - name: timespan
+        in: query
+        type: string
+        description: daily, weekly, monthly, yearly, or all (for most popular albums)
+        default: weekly
       responses:
         200:
           description: success

--- a/backend/apis.yaml
+++ b/backend/apis.yaml
@@ -46,6 +46,8 @@ paths:
           description: user info
         403:
           description: forbidden
+        404:
+          description: user not found
         405:
           description: invalid http method
         500:
@@ -193,7 +195,7 @@ paths:
       parameters:
       - name: query
         in: query
-        description: Search query (leave blank for global popular)
+        description: Search query (leave blank for most popular albums over past week)
         default: speak now
         type: string
       responses:
@@ -210,29 +212,27 @@ paths:
       tags:
       - reviews
       operationId: getReview
-      description: Specify sort to get all reviews for album. Specify username to get user's review for album.
+      description: __Specific to one album__ <br> • Current user's review for album - *albumID* (doesn't return array) <br> • Username's review for album - *albumID* and *username* (doesn't return array) <br> • Current user's followed user's reviews for album - *sort*, *albumID*, and *following*=*true* <br> • All reviews for album - *sort* and *albumID* <br><br> __All reviews__ <br> • All reviews by current user - *sort* <br> • All reviews by username - *sort* and *username* <br> • All reviews by current user's followed users - *sort*, and *following*=*true* <br><br> Any other combination will probably have unintended results.
       produces:
       - application/json
       security:
       - AccessToken: []
       parameters:
+      - name: sort
+        description: popular, newest, or oldest
+        in: query
+        type: string
+        default: popular
       - name: albumID
         in: query
         description: Spotify album ID
-        default: 4aawyAB9vmqN3uQ7FjRGTy
         type: string
-      - name: sort
-        in: query
-        description: popular, newest, or oldest
-        default: popular
-        type: string
-      - name: following
-        in: query
-        description: whether to get followers feed or not
-        type: boolean
       - name: username
         in: query
         type: string
+      - name: following
+        in: query
+        type: boolean
       responses:
         200:
           description: success

--- a/backend/apis.yaml
+++ b/backend/apis.yaml
@@ -46,8 +46,6 @@ paths:
           description: user info
         403:
           description: forbidden
-        404:
-          description: user not found
         405:
           description: invalid http method
         500:
@@ -195,8 +193,7 @@ paths:
       parameters:
       - name: query
         in: query
-        description: Search query
-        required: true
+        description: Search query (leave blank for global popular)
         default: speak now
         type: string
       responses:
@@ -213,27 +210,29 @@ paths:
       tags:
       - reviews
       operationId: getReview
-      description: __Specific to one album__ <br> • Current user's review for album - *albumID* (doesn't return array) <br> • Username's review for album - *albumID* and *username* (doesn't return array) <br> • Current user's followed user's reviews for album - *sort*, *albumID*, and *following*=*true* <br> • All reviews for album - *sort* and *albumID* <br><br> __All reviews__ <br> • All reviews by current user - *sort* <br> • All reviews by username - *sort* and *username* <br> • All reviews by current user's followed users - *sort*, and *following*=*true* <br><br> Any other combination will probably have unintended results.
+      description: Specify sort to get all reviews for album. Specify username to get user's review for album.
       produces:
       - application/json
       security:
       - AccessToken: []
       parameters:
-      - name: sort
-        description: popular, newest, or oldest
-        in: query
-        type: string
-        default: popular
       - name: albumID
         in: query
         description: Spotify album ID
+        default: 4aawyAB9vmqN3uQ7FjRGTy
         type: string
-      - name: username
+      - name: sort
         in: query
+        description: popular, newest, or oldest
+        default: popular
         type: string
       - name: following
         in: query
+        description: whether to get followers feed or not
         type: boolean
+      - name: username
+        in: query
+        type: string
       responses:
         200:
           description: success

--- a/backend/src/handlers/album/main.go
+++ b/backend/src/handlers/album/main.go
@@ -3,40 +3,35 @@ package main
 import (
 	"context"
 	"fmt"
-	"trill/src/models"
+	"trill/src/handlers"
 	"trill/src/utils"
 	"trill/src/views"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"gorm.io/gorm"
 )
 
-type Request = events.APIGatewayV2HTTPRequest
-type Response = events.APIGatewayV2HTTPResponse
+type Request = handlers.Request
+type Response = handlers.Response
 
 var db *gorm.DB
 
 func handler(ctx context.Context, req Request) (Response, error) {
-	if db == nil {
-		var err error
-		db, err = models.ConnectDB()
-		if err != nil {
-			return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
-		}
+	initCtx, err := handlers.InitContext(ctx, db)
+	if err != nil {
+		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}
-	ctx = context.WithValue(ctx, "db", db)
 
 	switch req.RequestContext.HTTP.Method {
 	case "GET":
-		return read(ctx, req)
+		return get(initCtx, req)
 	default:
 		err := fmt.Errorf("HTTP Method '%s' not allowed", req.RequestContext.HTTP.Method)
 		return Response{StatusCode: 405, Body: err.Error()}, err
 	}
 }
 
-func read(ctx context.Context, req Request) (Response, error) {
+func get(ctx context.Context, req Request) (Response, error) {
 	token, err := utils.GetSpotifyToken()
 	if err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil

--- a/backend/src/handlers/albums/main.go
+++ b/backend/src/handlers/albums/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"trill/src/handlers"
@@ -17,6 +18,11 @@ import (
 
 type Request = handlers.Request
 type Response = handlers.Response
+
+var (
+	ErrorTimespanParse error = errors.New("empty timespan parameter")
+	ErrorTimespan      error = errors.New("invalid value for timespan")
+)
 
 var db *gorm.DB
 
@@ -40,7 +46,24 @@ func handler(ctx context.Context, req Request) (Response, error) {
 }
 
 func getPopular(ctx context.Context, req Request) (Response, error) {
-	albumIDs, err := models.GetPopularAlbumsFromReviews(ctx)
+	timespan, ok := req.QueryStringParameters["timespan"]
+	if !ok {
+		return Response{StatusCode: 400, Body: ErrorTimespanParse.Error(), Headers: views.DefaultHeaders}, nil
+	}
+
+	switch timespan {
+	case
+		"daily",
+		"weekly",
+		"monthly",
+		"yearly",
+		"all":
+		break
+	default:
+		return Response{StatusCode: 400, Body: ErrorTimespan.Error(), Headers: views.DefaultHeaders}, nil
+	}
+
+	albumIDs, err := models.GetPopularAlbumsFromReviews(ctx, timespan)
 	if err != nil {
 		return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil
 	}

--- a/backend/src/handlers/common.go
+++ b/backend/src/handlers/common.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"context"
+	"trill/src/models"
+
+	"github.com/aws/aws-lambda-go/events"
+	"gorm.io/gorm"
+)
+
+type Request = events.APIGatewayV2HTTPRequest
+type Response = events.APIGatewayV2HTTPResponse
+
+func InitContext(ctx context.Context, db *gorm.DB) (context.Context, error) {
+	if db == nil {
+		var err error
+		db, err = models.ConnectDB()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return context.WithValue(ctx, "db", db), nil
+}

--- a/backend/src/handlers/hello/main.go
+++ b/backend/src/handlers/hello/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"github.com/aws/aws-lambda-go/events"
+	"trill/src/handlers"
+
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
@@ -9,9 +10,10 @@ import (
 // AWS Lambda Proxy Request functionality (default behavior)
 //
 // https://serverless.com/framework/docs/providers/aws/events/apigateway/#lambda-proxy-integration
-type Response events.APIGatewayV2HTTPResponse
+type Request = handlers.Request
+type Response = handlers.Response
 
-func Handler(req events.APIGatewayV2HTTPRequest) (Response, error) {
+func Handler(req Request) (Response, error) {
 	// yummers
 	return Response{StatusCode: 200, Body: "Hello"}, nil
 }

--- a/backend/src/handlers/paginate.go
+++ b/backend/src/handlers/paginate.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"trill/src/models"
+)
+
+var (
+	ErrorLimit error = errors.New("failed to parse limit")
+	ErrorPage  error = errors.New("failed to parse page")
+	// ErrorSort  error = errors.New("failed to parse sort")
+)
+
+type PaginateError struct {
+	Err error
+}
+
+func (e PaginateError) Error() string {
+	return fmt.Sprintf("pagination error: %s", e.Err.Error())
+}
+
+func GetPaginateFromRequest(ctx context.Context, req Request) (*models.Paginate, error) {
+	limit := models.PAGINATE_DEFAULT_LIMIT
+	page := models.PAGINATE_DEFAULT_PAGE
+	sort := models.PAGINATE_DEFAULT_SORT
+
+	var err error
+	for param, value := range req.QueryStringParameters {
+		switch param {
+		case "limit":
+			limit, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, PaginateError{Err: ErrorLimit}
+			}
+		case "page":
+			page, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, PaginateError{Err: ErrorPage}
+			}
+		case "sort":
+			sort = value
+		}
+	}
+
+	return &models.Paginate{
+		Limit: limit,
+		Page:  page,
+		Sort:  sort,
+	}, nil
+}

--- a/backend/src/handlers/paginate.go
+++ b/backend/src/handlers/paginate.go
@@ -9,9 +9,14 @@ import (
 )
 
 var (
-	ErrorLimit error = errors.New("failed to parse limit")
-	ErrorPage  error = errors.New("failed to parse page")
+	ErrorLimitParse   error = errors.New("failed to parse limit")
+	ErrorLimitTooHigh error = fmt.Errorf("maximum limit of %d exceeded", maxLimit)
+	ErrorPage         error = errors.New("failed to parse page")
 	// ErrorSort  error = errors.New("failed to parse sort")
+)
+
+var (
+	maxLimit int = 50
 )
 
 type PaginateError struct {
@@ -33,7 +38,10 @@ func GetPaginateFromRequest(ctx context.Context, req Request) (*models.Paginate,
 		case "limit":
 			limit, err = strconv.Atoi(value)
 			if err != nil {
-				return nil, PaginateError{Err: ErrorLimit}
+				return nil, PaginateError{Err: ErrorLimitParse}
+			}
+			if limit > maxLimit {
+				return nil, PaginateError{Err: ErrorLimitTooHigh}
 			}
 		case "page":
 			page, err = strconv.Atoi(value)

--- a/backend/src/handlers/reviews/main.go
+++ b/backend/src/handlers/reviews/main.go
@@ -122,11 +122,10 @@ func getReviews(ctx context.Context, req Request) (Response, error) {
 
 	var reviews *[]models.Review
 	switch paginate.Sort {
-	case "newest":
-		fallthrough
-	case "oldest":
-		fallthrough
-	case "popular":
+	case
+		"newest",
+		"oldest",
+		"popular":
 		reviews, err = models.GetReviews(ctx, &reviewQuery, users, paginate)
 		if err != nil {
 			return Response{StatusCode: 500, Body: err.Error(), Headers: views.DefaultHeaders}, nil

--- a/backend/src/handlers/usersCognito/main.go
+++ b/backend/src/handlers/usersCognito/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"trill/src/handlers"
 	"trill/src/models"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -15,14 +16,10 @@ type CognitoEvent = events.CognitoEventUserPoolsPostConfirmation
 var db *gorm.DB
 
 func create(ctx context.Context, req CognitoEvent) (CognitoEvent, error) {
-	if db == nil {
-		var err error
-		db, err = models.ConnectDB()
-		if err != nil {
-			return req, err
-		}
+	initCtx, err := handlers.InitContext(ctx, db)
+	if err != nil {
+		return req, err
 	}
-	ctx = context.WithValue(ctx, "db", db)
 
 	user := models.User{
 		Username:       req.UserName,
@@ -31,7 +28,7 @@ func create(ctx context.Context, req CognitoEvent) (CognitoEvent, error) {
 		ProfilePicture: "",
 	}
 
-	return req, models.CreateUser(ctx, &user)
+	return req, models.CreateUser(initCtx, &user)
 }
 
 func main() {

--- a/backend/src/models/common.go
+++ b/backend/src/models/common.go
@@ -57,5 +57,5 @@ func InitCognitoClient(ctx context.Context) (*CognitoClient, error) {
 }
 
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf(e.Err.Error())
+	return e.Err.Error()
 }

--- a/backend/src/models/paginate.go
+++ b/backend/src/models/paginate.go
@@ -1,0 +1,33 @@
+package models
+
+import "gorm.io/gorm"
+
+type Paginate struct {
+	Limit int
+	Page  int
+	Sort  string
+}
+
+var (
+	PAGINATE_DEFAULT_LIMIT = 50
+	PAGINATE_DEFAULT_PAGE  = 1
+	PAGINATE_DEFAULT_SORT  = "newest"
+)
+
+func BuildQueryFromPaginate(db *gorm.DB, pagination *Paginate) (*gorm.DB, error) {
+	offset := (pagination.Page - 1) * pagination.Limit
+	query := db.Limit(pagination.Limit).Offset(offset)
+	return query, query.Error
+}
+
+// func GetAllUsers(user *User, pagination *Pagination) (*[]User, error) {
+// 	var users []models.User
+// 	offset := (pagination.Page - 1) * pagination.Limit
+// 	queryBuider := Config.DB.Limit(pagination.Limit).Offset(offset).Order(pagination.Sort)
+// 	result := queryBuider.Model(&models.User{}).Where(user).Find(&users)
+// 	if result.Error != nil {
+// 		msg := result.Error
+// 		return nil, msg
+// 	}
+// 	return &users, nil
+// }

--- a/backend/src/models/reviews.go
+++ b/backend/src/models/reviews.go
@@ -97,7 +97,7 @@ func GetReviews(ctx context.Context, review *Review, following *[]User, paginate
 	return reviews, nil
 }
 
-func GetPopularAlbumsFromReviews(ctx context.Context) (*[]string, error) {
+func GetPopularAlbumsFromReviews(ctx context.Context, timespan string) (*[]string, error) {
 	db, err := GetDBFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,18 @@ func GetPopularAlbumsFromReviews(ctx context.Context) (*[]string, error) {
 	var results *[]struct {
 		AlbumID string
 	}
-	threshold := time.Now().Add(-7 * 24 * time.Hour)
+	day := -24 * time.Hour
+	threshold := time.Now()
+	switch timespan {
+	case "weekly":
+		threshold = threshold.Add(7 * day)
+	case "monthly":
+		threshold = threshold.Add(30 * day)
+	case "yearly":
+		threshold = threshold.Add(365 * day)
+	case "all":
+		threshold = time.Time{}
+	}
 
 	err = db.Model(&Review{}).
 		Select("album_id, COUNT(*) as count").


### PR DESCRIPTION
## Describe your changes

This implements a basic pagination framework for certain intensive database calls (for instance, GET reviews) so that a maximum of 50 rows are returned at once (this limit can be specified by the user to be something lower, however). This framework will eventually be applied to all endpoints that perform bulk retrievals. 

This also implements the Global Recent Popular Albums feature. This is hard-coded to only return the 10 most popular albums weekly by number of reviews and takes no parameters, though we can easily modify it to take date as a parameter.

Finally, some handler layer boilerplate was abstracted into a common handlers library.

**Testing Cases:**
`/albums?search={username}` - GET

- 200: Search functionality unchanged :heavy_check_mark: 

`/albums` - GET

- 200: Most popular albums as ranked by reviews made over the specified timespan is returned :heavy_check_mark: 
- 400: "empty timespan parameter" returned if no timespan is specified :heavy_check_mark: 
- 400: "invalid value for timespan" returned if timespan is not in {"daily", "weekly", "monthly", "yearly", or "all"} :heavy_check_mark: 

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Jira Cards

TSD-178, TSD-175

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
