### PR TITLE
[BUG FIX] Check if favorite albums is empty before rendering

### DIFF
--- a/web/src/components/Avatar.jsx
+++ b/web/src/components/Avatar.jsx
@@ -3,17 +3,20 @@ import { Link } from "react-router-dom";
 const AvatarComp = (props) =>{
     const { profilePic, username, size} = props.user;
     return (
-        <div className="avatar placeholder">
-            <div className={`bg-neutral-focus text-white rounded-full ring-2 ring-trillBlue hover:ring-white w-${size} h-${size}`}>
-                { profilePic ? 
-                    <img src={ profilePic } />
-                    :
-                    <span className={size === "24" ? "text-5xl text-white uppercase" : "text-md text-white uppercase"}>
-                        { username ? username[0]: "" }
-                    </span> 
-                }     
+        <div className="tooltip" data-tip={username}>
+            <div className="avatar placeholder">
+                <div className={`bg-neutral-focus text-white rounded-full ring-2 ring-trillBlue hover:ring-white w-${size} h-${size}`}>
+                    { profilePic ? 
+                        <img src={ profilePic } />
+                        :
+                        <span className={size === "24" ? "text-5xl text-white uppercase" : "text-md text-white uppercase"}>
+                            { username ? username[0]: "" }
+                        </span> 
+                    }     
+                </div>
             </div>
         </div>
+       
     );
 }
 

--- a/web/src/pages/Profile.jsx
+++ b/web/src/pages/Profile.jsx
@@ -120,9 +120,12 @@ function Profile() {
                 <div className="w-2/3 pr-12">
                     <Titles title="Favorite Albums"/>
                         <div className="text-white flex flex-row justify-left gap-5">
-                            {favoriteAlbums?.data?.map((favoriteAlbum) => (
+                        {Array.isArray(favoriteAlbums?.data) 
+                            ? favoriteAlbums.data.map((favoriteAlbum) => (
                                 <Album album={{...favoriteAlbum, size: "150"}} />
-                            ))} 
+                            ))
+                            : <h1 className="italic text-trillBlue">No favorite albums.</h1>
+                        }   
                         </div>
                 </div>
                 


### PR DESCRIPTION
## Describe your changes
- added tooltips to avatars
- fixed use case where user has not added any favorite albums yet by adding check for empty data

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Issue Jira ticket number and link

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
