### PR TITLE
Implement Listen Later

### DIFF
--- a/web/src/pages/ListenLater.jsx
+++ b/web/src/pages/ListenLater.jsx
@@ -1,40 +1,28 @@
 //Components
 import Titles from "../components/Titles";
 import Album from "../components/Album";
-
-let albumDummy = { 
-    "images": [{"url": "https://i.scdn.co/image/ab67616d0000b2732e8ed79e177ff6011076f5f0"}], 
-    "name": "Harry's House",
-    "artists": [
-        {
-            "name": "Harry Styles"
-        }
-    ],
-    "external_urls": {
-        "spotify": "https://open.spotify.com/album/5r36AJ6VOJtp00oxSkBZ5h"
-    },
-    "release_date": "2021",
-    "size": "100"
-}
+import { useQuery } from "@tanstack/react-query";
 
 function ListenLater() {
-    let dummyAlbums = [];
-    for (let i = 0; i < 10; i++) {
-        dummyAlbums.push(
-        <>
-            <Album album = {albumDummy} />
-        </>
-        );
-    }
+    const currentUser = localStorage.getItem("username");
+    const { isLoading, data: listenLater, refetch: refetchListenLater } = useQuery([`listenlateralbums?username=${currentUser}`]);
+
     return (
         <div className="max-w-6xl mx-auto">           
 
             <h1 className="font-bold text-3xl md:text-4xl text-white text-center pt-10 pb-10">Don't miss a beat. Save it for later.</h1>
             
-            <Titles title="You want to listen to 50 albums" />
+            <Titles title={`You want to listen to ${listenLater?.data.length} albums`}/>
             
-            <div className="text-white flex flex-row flex-wrap justify-center gap-4 max-w-6xl mx-auto">
-                {dummyAlbums}  
+            <div className="text-white flex flex-row flex-wrap justify-left gap-4 max-w-6xl mx-auto">
+                {isLoading 
+                    ?   "Loading..."
+                    :   Array.isArray(listenLater?.data) 
+                        ? listenLater.data.map((listenLater) => (
+                            <Album album={{...listenLater, size: "100"}} />
+                        ))
+                        : <h1 className="italic text-trillBlue">No albums in listen later.</h1>
+                }
             </div>
 
         </div>


### PR DESCRIPTION
## Describe your changes
- button on albums details can now add or remove from listen later
- albums will now populate on the listen later page 

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Describe current and new behavior if applicable. -->

## Issue Jira ticket number and link

## Screenshots or Gifs (if appropriate):

<!-- Gifs can be created using ShareX -->
![image](https://user-images.githubusercontent.com/42351353/224503477-597db0ef-20e9-4c3e-b209-e436cf415594.png)
